### PR TITLE
allow methods to set their own option defaults

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -98,7 +98,7 @@ const getEventEnvironmentArgs = () => ({
 });
 
 // event interface
-export default function wt(kind, payload = {}, options = {}) {
+export default function wt(kind, payload = {}, options) {
   if (kind === 'init' || kind === 'initialize') {
     initialize(payload, options);
   } else if (!context) {


### PR DESCRIPTION
@ksylvest 

`options` is often the third argument for tracker methods - leaving it undefined in the main function will let other methods set their own default args