### PR TITLE
Stop using Promise to avoid having to fix polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-## [v1.0.8] - Thursday, May 3, 2018
+## [v1.0.10] - Thursday, May 3, 2018
+
+ - Stop using promises for legacy support
+
 ## [v1.0.9] - Thursday, May 3, 2018
 
  - Fix for NPM import syntax

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [v1.0.8] - Thursday, May 3, 2018
+## [v1.0.9] - Thursday, May 3, 2018
 
  - Fix for NPM import syntax
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutter/wt",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "scripts": {
     "clean": "rimraf lib",
     "test": "cross-env BABEL_ENV=commonjs mocha test/index --compilers js:@babel/register --recursive",


### PR DESCRIPTION
To avoid having to setup a promise polyfill for legacy browsers (i.e. IE) simplifying to pass in resolve / reject callbacks.

Note: no CI (yet) so:

```
  wt-tracker.
    ✓ should load without error (613ms)
    ✓ should log one call (617ms)
    ✓ should handle after first load events (613ms)
    ✓ should hit the event emitter (612ms)
    ✓ should respect unsub (614ms)
    ✓ should enqueue calls while networking (715ms)
    ✓ should update defaults (613ms)
    ✓ should handle errors (613ms)
    ✓ should not double load (54ms)
    ✓ should process an empty queue (207ms)
    ✓ should update config
    ✓ should return an instance
    ✓ should guess root url based on context
    ✓ should update defaults with a function

  utils.debounce
    ✓ debounce should work (504ms)
    ✓ debounce flush should work
    ✓ debounce flush should not work with clear

  utils.uuid
    ✓ matches the uuid format
    ✓ generates a unique uuid


  19 passing (6s)

✨  Done in 7.54s.
```