### PR TITLE
favor query string for retrieving visitor token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,72 +2,76 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.1.0] - Thursday, December 26, 2019
+
+- If the visitor token is present in the query string, favor over the cookie
+- Include the visitor token in the request environment arguments sent to the server
+
 ## [v1.0.16] - Wednesday, April 24, 2019
 
-  - If cookie is not set it will set with expiration of 20 years
-  - Also, if application calls wt('initialize') then default cookie expiration will not apply and must be provided
+- If cookie is not set it will set with expiration of 20 years
+- Also, if application calls wt('initialize') then default cookie expiration will not apply and must be provided
 
 ## [v1.0.15] - Monday, Jan 28, 2019
 
-  - Set wt_page_uuid cookie if not present
+- Set wt_page_uuid cookie if not present
 
 ## [v1.0.14] - Monday, Dec 17, 2018
 
- - Fix page uuid having different uuid for unbounce.
+- Fix page uuid having different uuid for unbounce.
 
 ## [v1.0.13] - Wednesday, Dec 13, 2018
 
- - Generate page uuid if it not present.
+- Generate page uuid if it not present.
 
 ## [v1.0.12] - Wednesday, Dec 13, 2018
 
- - Add page uuid to events.
+- Add page uuid to events.
 
 ## [v1.0.11] - Wednesday, May 30, 2018
 
- - Add new fields to payload sent to WT server: page_name, container, position, object_type and object_name.
+- Add new fields to payload sent to WT server: page_name, container, position, object_type and object_name.
 
 ## [v1.0.10] - Thursday, May 3, 2018
 
- - Stop using promises for legacy support
+- Stop using promises for legacy support
 
 ## [v1.0.9] - Thursday, May 3, 2018
 
- - Fix for NPM import syntax
+- Fix for NPM import syntax
 
 ## [v1.0.8] - Monday, April 30, 2018
 
- - Generate client cookie for WT
+- Generate client cookie for WT
 
 ## [v1.0.7] - Monday, March 5, 2018
 
- - Added first load handler
+- Added first load handler
 
 ## [v1.0.6] - Friday, February 23, 2018
 
- - Change spelling of referer to referrer
+- Change spelling of referer to referrer
 
 ## [v1.0.5] - Thursday, February 22, 2018
 
- - Encoded URL Properly
+- Encoded URL Properly
 
 ## [v1.0.4] - Thursday, February 22, 2018
 
- - Added referrer as a value sent to the recipient image
+- Added referrer as a value sent to the recipient image
 
- ## [v1.0.3] - Thursday, February 11, 2018
+## [v1.0.3] - Thursday, February 11, 2018
 
-  - Added better defaults for context
+- Added better defaults for context
 
 ## [v1.0.2] - Thursday, February 8, 2018
 
- - Updated readme and added default for events
+- Updated readme and added default for events
 
 ## [v1.0.1] - Thursday, February 8, 2018
 
- - Fixed an unpkg issue.
-
+- Fixed an unpkg issue.
 
 ## [v1.0.0] - Thursday, February 8, 2018
 
- - Created WT library for webtracking.
+- Created WT library for webtracking.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutter/wt",
-  "version": "1.0.16",
+  "version": "1.1.0",
   "scripts": {
     "clean": "rimraf lib",
     "test": "cross-env BABEL_ENV=commonjs mocha test/index --compilers js:@babel/register --recursive",

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,13 @@ function retrieveFromCookie(key, config = {}) {
   return token;
 }
 
-const retrieveVisitorToken = (config = {}) => (
+const retrieveFromQueryString = (search) => {
+  const qs = QS.parse(search, { ignoreQueryPrefix: true });
+  return qs['wvt'];
+};
+
+const retrieveVisitorToken = (config = {}, search) => (
+  retrieveFromQueryString(search) ||
   retrieveFromCookie(VISITOR_TOKEN_KEY, config)
 );
 
@@ -92,7 +98,10 @@ export class WT {
   }
 
   getVisitorToken() {
-    return retrieveVisitorToken(this.wtConfig.cookies);
+    return retrieveVisitorToken(
+      this.wtConfig.cookies,
+      this.context.location && this.context.location.search,
+    );
   }
 
   getUUIDToken() {
@@ -146,6 +155,9 @@ export class WT {
       },
       agent: this.context.navigator.userAgent,
       rts: (new Date()).valueOf(),
+      wvt: retrieveFromQueryString(
+        this.context.location && this.context.location.search,
+      ),
     };
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ function retrieveFromCookie(key, config = {}) {
 
 const retrieveFromQueryString = (search) => {
   const qs = QS.parse(search, { ignoreQueryPrefix: true });
-  return qs['wvt'];
+  return qs.wvt;
 };
 
 const retrieveVisitorToken = (config = {}, search) => (

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,7 @@ const context = {
   location: {
     hostname: 'www.test.url',
     href: HREF,
+    search: 'wvt=testvisitortoken',
   },
   document: {
     referrer: 'test',
@@ -290,7 +291,16 @@ describe('wt-tracker.', () => {
     assert.match(events[1].page_uuid, /^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/, 'UUIDs must be formatted as a UUID');
   });
 });
+
 // TODO: write test to check cookie is properly set for wt_visitor_token and wt_page_uuid;
+describe('wt-visitor-token', () => {
+  it('should favor the visitor token in the query string', () => {
+    const qs = QS.parse(context.location.search);
+    const wvt = qs.wvt;
+
+    assert.equal(wt('getVisitorToken'), wvt);
+  });
+});
 
 describe('utils.debounce', () => {
   it('debounce should work', (done) => {


### PR DESCRIPTION
## Context
since we'll now be passing the visitor token through the query params we want to favor retrieving the visitor token from the params rather than the cookie to protect against situations where cookies are either disabled or cleared.

## Changes
adding a new function `retrieveFromQueryString` which receives `location.search` as an argument and will return the visitor token if it exists in the query string. This function is being used in `retrieveVisitorToken` and `getRequestEnvironmentArgs` which will allow the visitor token to be passed in the event payload to the server.