### PR TITLE
Fix send started event and param defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.1.1] - Thursday, November 19, 2020
+
+- Update 'SEND_STARTED' event to emit after it has actually started sending.
+- Update paramDefaults to be overridden by event data instead of the other way around.
+
 ## [v1.1.0] - Thursday, December 26, 2019
 
 - If the visitor token is present in the query string, favor over the cookie

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutter/wt",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "scripts": {
     "clean": "rimraf lib",
     "test": "cross-env BABEL_ENV=commonjs mocha test/index --compilers js:@babel/register --recursive",

--- a/src/index.js
+++ b/src/index.js
@@ -145,6 +145,7 @@ export class WT {
       reject();
     };
     this.loaderImage.src = `${this.getUrl()}?${query}`;
+    this.emitter.emit(SEND_STARTED);
   }
 
   getRequestEnvironmentArgs() {
@@ -181,7 +182,6 @@ export class WT {
     }
     const payload = assign({ events }, this.getRequestEnvironmentArgs());
     this.loading = true;
-    this.emitter.emit(SEND_STARTED);
 
     const resolve = () => {
       this.emitter.emit(SEND_COMPLETED);

--- a/src/index.js
+++ b/src/index.js
@@ -226,7 +226,7 @@ export class WT {
       position,
       object_type: objectType,
       object_name: objectName,
-      metadata: assign({}, args, this.paramDefaults),
+      metadata: assign({}, this.paramDefaults, args),
       ...this.getEventEnvironmentArgs(),
       ts: (new Date()).valueOf(),
     }, isNil));


### PR DESCRIPTION
- Fix the SEND_STARTED event to emit after it has actually started sending
- Update `paramDefaults` to be overridden by event metadata passed in (to behave more like a default)
  - Update tests to make this clearer to verify