### PR TITLE
Send events using POST

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,24 +2,17 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.9.4
+      - image: cimg/node:16.0.0
     steps:
       - checkout
-      - run:
-          name: update-npm
-          command: 'sudo npm install -g npm@latest'
       - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
-      - run:
-          name: install-npm
-          command: npm install
+          key: dependency-cache-{{ checksum "yarn.lock" }}
+      - run: yarn
       - save_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
+          key: dependency-cache-{{ checksum "yarn.lock" }}
           paths:
             - ./node_modules
-      - run:
-          name: test
-          command: npm test
+      - run: yarn test
       - run:
           name: nyc-dir
           command: 'mkdir .nyc_output'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.2.0] - Thursday, April 22, 2021
+
+- Send events using window.fetch()
+- Send event data in POST request body to avoid URI length limit
+
 ## [v1.1.1] - Thursday, November 19, 2020
 
 - Update 'SEND_STARTED' event to emit after it has actually started sending.

--- a/README.md
+++ b/README.md
@@ -15,16 +15,15 @@ button.addEventListener(
 );
 ```
 
-When `button` is clicked, this code will instantiate an `<img>` tag with the `src` attribute set to:
-`/track.gif?payload[][kind]=event&payload[][url]=CURRENT_URL&payload[][ts]=1517356691057&agent=Mozilla&rts=1517356691561`
+When `button` is clicked, this code will send event data to the server asynchronously using the polyfilled window.fetch() method.
 
-On the server, the endpoint `track.gif` is expected to return a valid image (for instance, a transparent pixel)
+On the server, the endpoint `/wt/t` is expected to return a valid response
 and to parse all the provided parameters, keeping track of the events sent by `wt`.
 
 # Why use wt
 
-The concept of `wt` is the same as Google Analytics: to use a transparent pixel to track events in the browser.
-The main difference is that `wt` is highly customizable and can send events to your own server, rather than to Google.
+The benefit of `wt` is to reliably track visitor events in the browser.
+`wt` is highly customizable and can send events to your own server, rather than third-party trackers.
 
 # How to install and load wt
 
@@ -43,33 +42,20 @@ import wt from '@clutter/wt';
 # How to use wt
 
 Events can be tracked with the function `wt(*string* kind, *object* params)`.
-For a single event, sent `kind` to `'event'` and pass any parameters you want to track in `params`.
+For a single event, set `kind` to `'event'` and pass any parameters you want to track in `params`.
 For instance:
 
 ```js
 wt('event', { action: 'hover' })
 ```
 
-will instantiate an `<img>` tag with the `src` attribute set to
-
-```
-/track.gif
- ?payload[][kind]=event
- &payload[][url]=CURRENT_URL
- &payload[][action]=hover
- &payload[][ts]=1517356691057
- &agent=Mozilla
- &rts=1517356691561
-```
-
-Breaking the URL down, `/track.gif` is followed by these query parameters:
-
-- `payload[][kind]`: the kind of tracking; in this case: `'event'`
-- `payload[][url]`: the URL of the page where the event occurred
-- `payload[][action]`: the only param to track in this case: `'hover'`
-- `payload[][ts]`: the timestamp when the event occurred (Unix-time milliseconds)
+The data sent to the server will contain the following:
+- `events[][kind]`: the kind of tracking; in this case: `'event'`
+- `events[][url]`: the URL of the page where the event occurred
+- `events[][action]`: the only param to track in this case: `'hover'`
+- `events[][ts]`: the timestamp when the event occurred (Unix-time milliseconds)
 - `agent`: the User Agent of the request
-- `rts`: the timestamp when the event was sent (that is, when the `src` attribute of the image was set)
+- `rts`: the timestamp when the event was sent
 
 ### How to track multiple events
 
@@ -83,29 +69,9 @@ wt('event', { action: 'click' })
 
 Under the hood, `wt` is optimized to deal with multiple events.
 
-Firstly, `wt` instantiates a *new* image only the first time `wt` is invoked.
-Every other time, `wt` changes the `src` attribute without creating a new image.
-
-Secondly, `wt` bundles multiple consecutive events into one request, if they occur within 1.5 seconds.
+`wt` bundles multiple consecutive events into one request, if they occur within 1.5 seconds.
 The goal is to avoid hitting the server too many times.
 If multiple events are sent in the same request, each request has its own payload.
-For instance, the URL for the two events above looks like this:
-
-```
-/track.gif
- ?payload[][kind]=event
- &payload[][url]=CURRENT_URL
- &payload[][action]=hover
- &payload[][ts]=1517356691057
- ?payload[][kind]=event
- &payload[][url]=CURRENT_URL
- &payload[][action]=click
- &payload[][ts]=1517356691257
- &agent=Mozilla
- &rts=1517356691561
-```
-
-This format of array in query parameters is particularly optimized for Rails.
 
 ### How to track a pageview
 
@@ -113,14 +79,14 @@ This format of array in query parameters is particularly optimized for Rails.
 wt('pageview')
 ```
 
-### How to change the location of the tracking image
+### How to change the location of the tracking endpoint
 
-By default, `wt` expects the image to be located at `/track.gif` in the same host as the current page.
-This can be changed by initializing `wt` with a different `trackerUrl` before tracking:
+By default, `wt` expects the tracker domain to be the same host as the current page.
+This can be changed by initializing `wt` with a different `trackerDomain` before tracking:
 
 ```js
 wt('initialize', {
-  trackerUrl: 'www.my-pixel-endpoint.com/track.gif',
+  trackerDomain: 'www.my-pixel-endpoint.com',
 });
 ```
 
@@ -160,7 +126,7 @@ If part of the payload is the same for every event, it can be set once using `se
 ```js
 wt('set', {
   user: {
-   id: 1  
+   id: 1
   },
 });
 ```
@@ -226,6 +192,6 @@ wt('afterFirstLoad', () => {
 
 # How to implement the server
 
-In order for `wt` to fully work, a server must be running that provides a `track.gif` endpoint.
+In order for `wt` to fully work, a server must be running that provides a `/wt/t` endpoint.
 This can be built in Rails, node.js or any other technology.
 An example is provided inside the repo at `examples/index.server.js`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutter/wt",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "scripts": {
     "clean": "rimraf lib",
     "test": "cross-env BABEL_ENV=commonjs mocha test/index --compilers js:@babel/register --recursive",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "main": "lib/index.js",
   "dependencies": {
     "js-cookie": "^2.2.0",
-    "qs": "^6.5.1"
+    "qs": "^6.5.1",
+    "whatwg-fetch": "^3.6.2"
   },
   "files": [
     "lib",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import QS from 'qs';
 import Cookie from 'js-cookie';
 import EventEmitter from 'events';
+import { fetch } from 'whatwg-fetch';
 import { debounce, isFunction, assign, omitBy, isNil, uuid } from './utils';
 
 export const DEBOUNCE_MIN = 500;
@@ -144,7 +145,20 @@ export class WT {
       delete this.loaderImage.onload;
       reject();
     };
-    this.loaderImage.src = `${this.getUrl()}?${query}`;
+
+    fetch(`${this.getRoot()}/wt/t`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: query,
+    })
+      .then(() => {
+        resolve();
+      })
+      .catch(() => {
+        this.loaderImage.src = `${this.getUrl()}?${query}`;
+      });
     this.emitter.emit(SEND_STARTED);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -157,7 +157,7 @@ export class WT {
         resolve();
       })
       .catch(() => {
-        this.loaderImage.src = `${this.getUrl()}?${query}`;
+        this.loaderImage.src = `${this.getUrl()}?fallback=true&${query}`;
       });
     this.emitter.emit(SEND_STARTED);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5552,6 +5552,11 @@ websocket-extensions@>=0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
 
+whatwg-fetch@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
+
 which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"


### PR DESCRIPTION
## Pivotal ticket(s)
https://www.pivotaltracker.com/story/show/177824064

## Context
[WT Event Fixes Spec](https://docs.google.com/document/d/1RJJDpNNHmMhM94-EL1Go0TdYQS9czFoBx07d_Q1UYvk/edit#)
> Missing WT events have been a recurring problem since WT events first launched. Adblockers can affect the efficacy of our pixels (and even prevent them from appearing in fullstory). There are some low-hanging-fruit steps we can take to reduce the impact of adblockers and have a higher integrity events dataset. 

## Changes
- Send events to `/wt/t` with `POST` method using window.fetch()
- Fallback to image pixel tracking if `window.fetch()` fails (plan is to remove in the future)
- Send data in POST request body to avoid "URI Too Long" error:

<img width="825" alt="Screen Shot 2021-04-21 at 2 54 32 PM" src="https://user-images.githubusercontent.com/7897569/115764177-1a62d180-a35a-11eb-9233-41713164885e.png">


## Test Cases
Tested on macallan
- Published an rc version to npm with `@clutter/wt@1.2.0-rc.1`
- Pointed landing branch to rc version: https://github.com/clutter/landing/pull/2003
- Updated wt gem for new wt endpoint: https://github.com/clutter/clutter-platform/pull/11408

See events on macallan:
```
select * from wt_events order by created_at desc limit 30
```

Chrome:
<img width="1069" alt="Screen Shot 2021-04-23 at 7 23 30 AM" src="https://user-images.githubusercontent.com/7897569/115885453-d7116d00-a404-11eb-89d1-e4f2c669c7e3.png">


Firefox:
<img width="1705" alt="Screen Shot 2021-04-22 at 11 47 19 PM" src="https://user-images.githubusercontent.com/7897569/115885298-af220980-a404-11eb-9b0a-90c576256448.png">


Safari:
<img width="1062" alt="Screen Shot 2021-04-22 at 11 48 39 PM" src="https://user-images.githubusercontent.com/7897569/115885320-b47f5400-a404-11eb-9f1f-aeb2cfa59269.png">




## Callouts
wt changes: https://github.com/clutter/wt/pull/62

## Future
- Removing pixel fallback (if we don't see many fallback=true requests after we deploy)
- Use sendBeacon with polyfill? Not sure if we still want this if things work well with fetch/POST
- Use prettier
- (Optional) Update circleci config