### PR TITLE
Send cookies when making track request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.2.1] - Friday, April 23, 2021
+
+- Send cookies in tracking request to preserve visitor association
+
 ## [v1.2.0] - Thursday, April 22, 2021
 
 - Send events using window.fetch()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutter/wt",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "scripts": {
     "clean": "rimraf lib",
     "test": "cross-env BABEL_ENV=commonjs mocha test/index --compilers js:@babel/register --recursive",

--- a/src/index.js
+++ b/src/index.js
@@ -148,6 +148,7 @@ export class WT {
 
     fetch(`${this.getRoot()}/wt/t`, {
       method: 'POST',
+      credentials: 'include',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
       },


### PR DESCRIPTION
## Pivotal ticket(s)
https://www.pivotaltracker.com/story/show/177895807

## Context
A bug was introduced in https://github.com/clutter/wt-client/pull/36 where our `window.fetch()` request does not send cookies to the server because by default, cookies are not sent for cross-origin requests. The fix is to set `credentials: 'include'` to include cookies in this request. See [docs](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters) for more info.

The server must also be updated to allow credentials to be sent.

## Changes
- Set `credentials: 'include'` in `fetch()` options to send cookies to the server

Before: Cookie not sent in request
![request_before](https://user-images.githubusercontent.com/7897569/115943836-12448800-a467-11eb-82fb-c0612a0d60c8.png)

After: Cookie sent in request
<img width="761" alt="Screen Shot 2021-04-23 at 7 07 42 PM" src="https://user-images.githubusercontent.com/7897569/115943865-3738fb00-a467-11eb-870c-37e8465553ee.png">


## Test Cases
Tested on macallan

Before:
We created 56 visitors for the same page uuid
```
select page_uuid, count(distinct visitor_id), count(*) as total_event_count
from wt_events
where page_uuid = '4b739048-043f-46b4-aae5-e85990ba0222'
group by 1

=>
page_uuid,count,total_event_count
4b739048-043f-46b4-aae5-e85990ba0222,56,145
```

After:
We created 1 visitor for the same page uuid
```
select page_uuid, count(distinct visitor_id) as distinct_visitors, count(*) as total_event_count
from wt_events
where page_uuid = 'f2410c93-7c8e-4322-9c46-b5d261136cc3'
group by 1

=>
page_uuid,distinct_visitors,total_event_count
f2410c93-7c8e-4322-9c46-b5d261136cc3,1,131
```

## Callouts
Merge order:
1. https://github.com/clutter/wt-client/pull/38
2. https://github.com/clutter/clutter-platform/pull/11427
3. https://github.com/clutter/landing/pull/2015