### PR TITLE
Bump React types to ^18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutter/wt",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "scripts": {
     "test": "jest",
     "test:watch": "jest -w",
@@ -42,7 +42,7 @@
     "@types/js-cookie": "^3.0.0",
     "@types/lodash": "^4.14.175",
     "@types/qs": "^6.9.7",
-    "@types/react": "^17",
+    "@types/react": "^18",
     "concurrently": "^3.5.1",
     "esbuild": "^0.14",
     "esbuild-jest": "^0.5.0",

--- a/src/react.tsx
+++ b/src/react.tsx
@@ -29,10 +29,10 @@ export const createProvider = <
     },
   });
 
-  const WTProvider: React.FC<{ params: Partial<Params> }> = ({
-    params,
-    children,
-  }) => {
+  const WTProvider: React.FC<{
+    children: React.ReactNode;
+    params: Partial<Params>;
+  }> = ({ params, children }) => {
     const paramRef = useRef(params);
     const { params: parentParams } = useContext(WTContext);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -759,10 +759,10 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
-"@types/react@^17":
-  version "17.0.30"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.30.tgz#2f8e6f5ab6415c091cc5e571942ee9064b17609e"
-  integrity sha512-3Dt/A8gd3TCXi2aRe84y7cK1K8G+N9CZRDG8kDGguOKa0kf/ZkSwTmVIDPsm/KbQOVMaDJXwhBtuOXxqwdpWVg==
+"@types/react@^18":
+  version "18.0.12"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.12.tgz#cdaa209d0a542b3fcf69cf31a03976ec4cdd8840"
+  integrity sha512-duF1OTASSBQtcigUvhuiTB1Ya3OvSy+xORCiEf20H0P0lzx+/KeVsA99U5UjLXSbyo1DRJDlLKqTeM1ngosqtg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
## Pivotal Ticket
https://www.pivotaltracker.com/story/show/182459361

## Context
- `@types/react@^18` removed the default `children` prop

## Changes
- Bump React types to v18 for children update

