### PR TITLE
Fix WTProvider props and confusing metadata behavior

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutter/wt",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "scripts": {
     "test": "jest",
     "test:watch": "jest -w",

--- a/src/client.ts
+++ b/src/client.ts
@@ -109,6 +109,7 @@ export type WTEventParams = {
   position?: string | number;
   objectType?: string;
   objectName?: string;
+  metadata?: Record<string, any>;
   [metadataKey: string]: any;
 };
 
@@ -214,6 +215,7 @@ export class WT {
       position,
       objectType,
       objectName,
+      metadata,
       ...args
     } = params;
     this.eventQueue.push(
@@ -229,7 +231,7 @@ export class WT {
           position,
           object_type: objectType,
           object_name: objectName,
-          metadata: { ...this.paramDefaults, ...args },
+          metadata: { ...this.paramDefaults, ...metadata, ...args },
           ...this.getEventEnvironmentArgs(),
           ts: new Date().valueOf(),
         },

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,13 +1,13 @@
-import QS from "qs";
-import Cookie from "js-cookie";
-import EventEmitter from "events";
-import { debounce, isFunction, omitBy, isNil, uuid } from "./utils";
+import QS from 'qs';
+import Cookie from 'js-cookie';
+import EventEmitter from 'events';
+import { debounce, isFunction, omitBy, isNil, uuid } from './utils';
 
 const DEBOUNCE_MIN_DEFAULT = 500;
 const DEBOUNCE_MAX_DEFAULT = 1500;
 
 const DEFAULT_STRINGIFY_OPTIONS = {
-  arrayFormat: "brackets",
+  arrayFormat: 'brackets',
   skipNulls: true,
   encode: true,
 } as const;
@@ -20,13 +20,13 @@ function resolveMethod<V>(val: V | ((...a: any[]) => V), ...args: any[]) {
   return isFunction(val) ? val(...args) : val;
 }
 
-export const SEND_STARTED = "send:started";
-export const SEND_COMPLETED = "send:completed";
-export const QUEUE_COMPLETED = "queue:completed";
-export const QUEUE_CONTINUED = "queue:continued";
+export const SEND_STARTED = 'send:started';
+export const SEND_COMPLETED = 'send:completed';
+export const QUEUE_COMPLETED = 'queue:completed';
+export const QUEUE_CONTINUED = 'queue:continued';
 
-export const VISITOR_TOKEN_KEY = "wt_visitor_token";
-export const PAGE_UUID_KEY = "wt_page_uuid";
+export const VISITOR_TOKEN_KEY = 'wt_visitor_token';
+export const PAGE_UUID_KEY = 'wt_page_uuid';
 
 function retrieveFromCookie(key: string, config: Cookie.CookieAttributes = {}) {
   let token = Cookie.get(key);
@@ -165,11 +165,11 @@ export class WT {
 
   public track(kindOrParams: string | WTEventParams) {
     const resolvedParams =
-      typeof kindOrParams === "string" ? { kind: kindOrParams } : kindOrParams;
+      typeof kindOrParams === 'string' ? { kind: kindOrParams } : kindOrParams;
 
     this.addToQueue({
       ...resolvedParams,
-      kind: resolvedParams.kind ?? "event",
+      kind: resolvedParams.kind ?? 'event',
     });
   }
 
@@ -282,10 +282,10 @@ export class WT {
     };
 
     fetch(`${this.getRoot()}/wt/t`, {
-      method: "POST",
-      credentials: "include",
+      method: 'POST',
+      credentials: 'include',
       headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
+        'Content-Type': 'application/x-www-form-urlencoded',
       },
       body: query,
     })

--- a/src/react.tsx
+++ b/src/react.tsx
@@ -4,8 +4,8 @@ import React, {
   useEffect,
   useMemo,
   useRef,
-} from "react";
-import { WTEventParams } from "./client";
+} from 'react';
+import { WTEventParams } from './client';
 
 type ContextValue<Params = Record<string, any>> = {
   params: React.RefObject<Partial<Params>>;
@@ -25,14 +25,14 @@ export const createProvider = <
   const WTContext = React.createContext<ContextValue<Params>>({
     params: { current: {} },
     track: () => {
-      throw new Error("No WTProvider found");
+      throw new Error('No WTProvider found');
     },
   });
 
   const WTProvider: React.FC<{
     children: React.ReactNode;
-    params: Partial<Params>;
-  }> = ({ params, children }) => {
+    params?: Partial<Params>;
+  }> = ({ params = {}, children }) => {
     const paramRef = useRef(params);
     const { params: parentParams } = useContext(WTContext);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 /** @internal */
 export const isFunction = (val: any): val is (...args: any[]) => any =>
-  Object.prototype.toString.call(val) === "[object Function]";
+  Object.prototype.toString.call(val) === '[object Function]';
 
 /** @internal */
 export const debounce = <F extends (...args: any) => any>(
@@ -71,10 +71,10 @@ export const omitBy = <
 
 /** @internal */
 export const uuid = () =>
-  "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (character) => {
+  'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (character) => {
     /* eslint-disable no-bitwise, no-mixed-operators */
     const seed = (Math.random() * 16) | 0;
-    const value = character === "x" ? seed : (seed & 0x3) | 0x8;
+    const value = character === 'x' ? seed : (seed & 0x3) | 0x8;
     /* eslint-enable no-bitwise, no-mixed-operators */
 
     return value.toString(16);

--- a/src/wt.ts
+++ b/src/wt.ts
@@ -1,10 +1,10 @@
-import { createProvider } from "./react";
-import wt, { WTEventParams } from "./client";
+import { createProvider } from './react';
+import wt, { WTEventParams } from './client';
 
 const { WTProvider, useTrack, useWT } = createProvider(
   (params: WTEventParams) => wt.track(params)
 );
 
 export default wt;
-export * from "./client";
+export * from './client';
 export { WTProvider, useTrack, useWT, createProvider };

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -164,6 +164,22 @@ describe("wt-tracker.", () => {
     });
   });
 
+  it("merges metadata if provided directly as a param", (done) => {
+    const events = [{ metadata: { foo: "bar" }, baz: "qux" }];
+    runEvents(events, (result) => {
+      expect(result).toEqual([
+        {
+          kind: "event",
+          metadata: { foo: "bar", baz: "qux" },
+          page_uuid: pageUuid,
+          referrer: "test",
+          url: HREF,
+        },
+      ]);
+      done();
+    });
+  });
+
   it("should hit the event emitter", (done) => {
     const events = [{ hello: "world", url: HREF }];
     let touched = false;


### PR DESCRIPTION
## Changes
- Make passing `params` to `<WTProvider	/>` optional
- Support explicitly passing a `metadata` property (previously this would result in a nested structure, e.g. `{ metadata: { metadata: { foo: 'bar' } }`)
  - This also makes strictly typing events easier as it allows for an explicit limit on the possible keys
- Specify prettier quote behavior (this prevents possible local issues where a different version of prettier is used with changed defaults)
