### PR TITLE
Support passing schema param

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutter/wt",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "scripts": {
     "test": "jest",
     "test:watch": "jest -w",

--- a/src/client.ts
+++ b/src/client.ts
@@ -110,6 +110,7 @@ export type WTEventParams = {
   objectType?: string;
   objectName?: string;
   metadata?: Record<string, any>;
+  schema?: string;
   [metadataKey: string]: any;
 };
 
@@ -216,6 +217,7 @@ export class WT {
       objectType,
       objectName,
       metadata,
+      schema,
       ...args
     } = params;
     this.eventQueue.push(
@@ -231,6 +233,7 @@ export class WT {
           position,
           object_type: objectType,
           object_name: objectName,
+          schema,
           metadata: { ...this.paramDefaults, ...metadata, ...args },
           ...this.getEventEnvironmentArgs(),
           ts: new Date().valueOf(),


### PR DESCRIPTION
## Context
We're adding support for schema based event validation to the `wt` gem.

## Changes
Add `schema` to allowed params

