### PR TITLE
Send track requests as JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutter/wt",
-  "version": "2.1.0",
+  "version": "3.0.0-alpha.1",
   "scripts": {
     "test": "jest",
     "test:watch": "jest -w",

--- a/src/client.ts
+++ b/src/client.ts
@@ -53,6 +53,9 @@ const retrievePageUUIDToken = () => retrieveFromCookie(PAGE_UUID_KEY);
 
 type WTConfig = {
   cookieOptions?: Cookies.CookieAttributes;
+  fetchConfig?: Omit<RequestInit, 'headers'> & {
+    headers?: Record<string, string>;
+  };
   trackerUrl?: string;
   trackerDomain?: string;
   stringifyOptions?: QS.IStringifyOptions;
@@ -287,10 +290,13 @@ export class WT {
     fetch(`${this.getRoot()}/wt/t`, {
       method: 'POST',
       credentials: 'include',
+      body: JSON.stringify(payload),
       headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Type': 'text/plain',
+        ...this.wtConfig.fetchConfig?.headers,
       },
-      body: query,
+      keepalive: true,
+      ...this.wtConfig.fetchConfig,
     })
       .then(() => {
         resolve();


### PR DESCRIPTION
## Changes
- Allow configuring fetch options for posting track requests
- Default to sending a JSON body with `content-type: text-plain` header to bypass CORS 

## Callouts
- Intending to release as v3 alpha as this is a breaking change depending on server implementation, but there are several other changes planned for (namely removing the image fallback)