### PR TITLE
Fix visitor token override position

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutter/wt",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "scripts": {
     "test": "jest",
     "test:watch": "jest -w",

--- a/src/client.ts
+++ b/src/client.ts
@@ -47,6 +47,7 @@ const retrievePageUUIDToken = () => findOrSetCookie(PAGE_UUID_KEY);
 
 type WTConfig = {
   cookieOptions?: Cookies.CookieAttributes;
+  visitorToken?: string;
   fetchConfig?: Omit<RequestInit, 'headers'> & {
     headers?: Record<string, string>;
   };
@@ -107,10 +108,10 @@ export type WTEventParams = {
   objectName?: string;
   metadata?: Record<string, any>;
   schema?: string;
-  visitorToken?: string;
 };
 
 export type WTPayload = {
+  visitor_token?: string;
   events: WTEvent[];
   dimensions: {
     width: number;
@@ -148,9 +149,12 @@ export class WT {
   }
 
   public getVisitorToken() {
-    return getVisitorToken(
-      this.wtConfig.cookieOptions,
-      this.context.location && this.context.location.search
+    return (
+      this.wtConfig.visitorToken ||
+      getVisitorToken(
+        this.wtConfig.cookieOptions,
+        this.context.location && this.context.location.search
+      )
     );
   }
 
@@ -259,6 +263,7 @@ export class WT {
 
   private getRequestEnvironmentArgs() {
     return {
+      visitor_token: this.wtConfig.visitorToken,
       dimensions: {
         width: this.context.innerWidth,
         height: this.context.innerHeight,

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -73,7 +73,7 @@ describe('wt-tracker.', () => {
     Cookies.set(PAGE_UUID_KEY, pageUuid);
     wt = withContext(context);
     wt.initialize({
-      trackerUrl: 'pixel.test.url/pixel.gif',
+      trackerDomain: 'pixel.test.com',
       debounce: {
         min: DEBOUNCE_MIN_DEFAULT,
       },
@@ -262,16 +262,15 @@ describe('wt-tracker.', () => {
   /* eslint-enable no-shadow */
 
   it('should update config', () => {
-    const config = { trackerUrl: 'https://google.com' };
+    const config = { trackerDomain: 'https://google.com' };
     wt.config(config);
 
-    expect(wt['wtConfig'].trackerUrl).toEqual(config.trackerUrl);
+    expect(wt['wtConfig'].trackerDomain).toEqual(config.trackerDomain);
   });
 
   it('should guess root url based on context', () => {
     wt.initialize({
       trackerDomain: undefined,
-      trackerUrl: undefined,
     });
     let root = wt['getRoot']();
     expect(root).toEqual(`//${context.location.hostname}`);
@@ -282,8 +281,8 @@ describe('wt-tracker.', () => {
   });
 
   it('should update defaults with a function', () => {
-    const paramDefaults = { userId: '1' };
-    wt.set(() => paramDefaults);
+    const paramDefaults = { metadata: { userId: '1' } };
+    wt.set(paramDefaults);
     expect(paramDefaults).toEqual(wt['paramDefaults']);
   });
 


### PR DESCRIPTION
## Context
This was supposed to be a top level param, but @nopelluhh put it in the wrong spot 🙃 

## Changes
- Clean up unnoticed type errors in the client spec
- Move custom visitor token setting to `config` call and add test cases for sending events + reading visitor token