### PR TITLE
Include error in onError callback

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,7 @@
   "extends": "clutter",
   "ignorePatterns": ["test/**", "scripts/**", "dist/**"],
   "rules": {
-    "lines-between-class-members": "off"
+    "lines-between-class-members": "off",
+    "max-classes-per-file": "off"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutter/wt",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "scripts": {
     "test": "jest",
     "test:watch": "jest -w",


### PR DESCRIPTION
## Context
The latest version of WT moved to only using fetch as a transport and added a callback for when events fail to send for any reason, but didn't include any information to help diagnose why the event failed to send.

## Changes
- Add caught error as a second parameter to the `onError` callback
